### PR TITLE
Fix project title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Flyte CoPilot
+# Flyte CoPilot
 
 ## Overview
 Flyte CoPilot provides a sidecar that understand Flyte Metadata Format as specified in FlyteIDL and make it possible to run arbitrary containers in Flyte.


### PR DESCRIPTION
The project title - `Flyte CoPilot` was not rendering
properly in Markdown because of a missing space.

Signed-off-by: Tanay Tummalpalli <ttanay100@gmail.com>

# TL;DR
Fixes project title rendering in Markdown

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The project title for Flyte CoPilot is missing a space because of which it couldn't be rendered properly. 
![flyte_copilot](https://user-images.githubusercontent.com/26265392/136259865-4719c6c1-abf8-4894-a95b-a04510a8146f.png)

Note: This is a small change, but, I got familiar with the contributing process. 

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1576

## Follow-up issue
_NA_
