### PR TITLE
Fix command line config parsing #minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .idea
+artifacts/*

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,8 @@ linux_compile:
 .PHONY: compile
 compile:
 	mkdir -p ./artifacts
-	go build -o ../artifacts/flyte-copilot .
+	go build -o ./artifacts/flyte-copilot .
 
 cross_compile:
-	@glide install
 	@mkdir -p ./artifacts/cross
-	GOOS=linux GOARCH=amd64 go build -o ../artifacts/flyte-copilot .
+	GOOS=linux GOARCH=amd64 go build -o ./artifacts/flyte-copilot .

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,8 +168,13 @@ func (r *RootOptions) initConfig(cmd *cobra.Command, _ []string) error {
 		SearchPaths: []string{r.cfgFile},
 	})
 
+	rootCmd := cmd
+	for rootCmd.Parent() != nil {
+		rootCmd = rootCmd.Parent()
+	}
+
 	// persistent flags were initially bound to the root command so we must bind to the same command to avoid
-	r.configAccessor.InitializePflags(cmd.PersistentFlags())
+	r.configAccessor.InitializePflags(rootCmd.PersistentFlags())
 
 	err := r.configAccessor.UpdateConfig(context.TODO())
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/aws/aws-sdk-go v1.37.1
 	github.com/flyteorg/flyteidl v0.18.15
-	github.com/flyteorg/flytestdlib v0.3.33
+	github.com/flyteorg/flytestdlib v0.4.2
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flyteorg/flyteidl v0.18.15 h1:sXrlwTRaRjQsXYMNrY/S930SKdKtu4XnpNFEu8I4tn4=
 github.com/flyteorg/flyteidl v0.18.15/go.mod h1:b5Fq4Z8a5b0mF6pEwTd48ufvikUGVkWSjZiMT0ZtqKI=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
-github.com/flyteorg/flytestdlib v0.3.33 h1:+oCx3zXUIldL7CWmNMD7PMFPXvGqaPgYkSKn9wB6qvY=
-github.com/flyteorg/flytestdlib v0.3.33/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
+github.com/flyteorg/flytestdlib v0.4.2 h1:3xYcxOj6ltMCR8weuXhV8hp5UTsAqb7uS3q8LZGvEKA=
+github.com/flyteorg/flytestdlib v0.4.2/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>


# TL;DR
To parse Config from CLI, you need to use the rootcmd. this PR traverses to the root to add init the pflags

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1782

## Follow-up issue
_NA_

