### PR TITLE
Add support upload collections

### DIFF
--- a/data/common.go
+++ b/data/common.go
@@ -1,8 +1,9 @@
 // This module contains Flyte CoPilot related code.
 // Currently it only has 2 utilities - downloader and an uploader.
 // Usage Downloader:
-//  downloader := NewDownloader(...)
-//  downloader.DownloadInputs(...) // will recursively download all inputs
+//
+//	downloader := NewDownloader(...)
+//	downloader.DownloadInputs(...) // will recursively download all inputs
 //
 // Usage uploader:
 // uploader := NewUploader(...)

--- a/data/upload.go
+++ b/data/upload.go
@@ -216,7 +216,6 @@ func (u Uploader) RecursiveUpload(ctx context.Context, vars *core.VariableMap, f
 			return fmt.Errorf("IllegalState, expected core.Literal, received [%s]", reflect.TypeOf(v))
 		}
 		outputs.Literals[k] = l
-		logger.Infof(ctx, "llll [%s]", l)
 		logger.Infof(ctx, "Var [%s] completed", k)
 	}
 


### PR DESCRIPTION
# TL;DR
Add support upload collection (a list).
When using raw container in the map task, flytepropeller expect the [subtask upload a list](https://github.com/flyteorg/flyteplugins/blob/f577f62727a16a282edfa7a49d985e47a4ccef79/go/tasks/plugins/array/outputs.go#L121).

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://flyte-org.slack.com/archives/CP2HDHKE1/p1678230956906899

## Follow-up issue
_NA_
