### PR TITLE
Lazily initialize kubernetes client only when using kube api watcher

### DIFF
--- a/cmd/containerwatcher/kubeapi_watcher.go
+++ b/cmd/containerwatcher/kubeapi_watcher.go
@@ -8,7 +8,9 @@ import (
 	v13 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type ContainerInformation struct {
@@ -80,6 +82,14 @@ func (k kubeAPIWatcher) WaitToExit(ctx context.Context) error {
 	return k.wait(ctx, k.info, f)
 }
 
-func NewKubeAPIWatcher(_ context.Context, coreClient v1.CoreV1Interface, info ContainerInformation) (Watcher, error) {
-	return kubeAPIWatcher{coreClient: coreClient, info: info}, nil
+func NewKubeAPIWatcher(_ context.Context, clientConfig clientcmd.ClientConfig, info ContainerInformation) (Watcher, error) {
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return kubeAPIWatcher{}, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return kubeAPIWatcher{}, err
+	}
+	return kubeAPIWatcher{coreClient: kubeClient.CoreV1(), info: info}, nil
 }

--- a/cmd/containerwatcher/kubeapi_watcher.go
+++ b/cmd/containerwatcher/kubeapi_watcher.go
@@ -85,11 +85,11 @@ func (k kubeAPIWatcher) WaitToExit(ctx context.Context) error {
 func NewKubeAPIWatcher(_ context.Context, clientConfig clientcmd.ClientConfig, info ContainerInformation) (Watcher, error) {
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
-		return kubeAPIWatcher{}, err
+		return kubeAPIWatcher{info: info}, err
 	}
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return kubeAPIWatcher{}, err
+		return kubeAPIWatcher{info: info}, err
 	}
 	return kubeAPIWatcher{coreClient: kubeClient.CoreV1(), info: info}, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,8 +24,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 )
@@ -34,8 +32,6 @@ type RootOptions struct {
 	*clientcmd.ConfigOverrides
 	showSource     bool
 	clientConfig   clientcmd.ClientConfig
-	restConfig     *rest.Config
-	kubeClient     kubernetes.Interface
 	Scope          promutils.Scope
 	Store          *storage.DataStore
 	configAccessor config.Accessor
@@ -129,7 +125,7 @@ func NewDataCommand() *cobra.Command {
 				return errors.Wrap(err, "failed to create datastore client")
 			}
 			rootOpts.Store = store
-			return rootOpts.ConfigureClient()
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return rootOpts.executeRootCmd()
@@ -179,20 +175,6 @@ func (r *RootOptions) initConfig(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-func (r *RootOptions) ConfigureClient() error {
-	restConfig, err := r.clientConfig.ClientConfig()
-	if err != nil {
-		return err
-	}
-	k, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return err
-	}
-	r.restConfig = restConfig
-	r.kubeClient = k
 	return nil
 }
 

--- a/cmd/sidecar.go
+++ b/cmd/sidecar.go
@@ -181,6 +181,6 @@ func NewUploadCommand(opts *RootOptions) *cobra.Command {
 	uploadCmd.Flags().StringVarP(&uploadOptions.exitWatcherType, "exit-watcher-type", "", containerwatcher.WatcherTypeSharedProcessNS, fmt.Sprintf("Sidecar will wait for completion of the container before starting upload process. Watcher type makes the type configurable. Available Type %+v", containerwatcher.AllWatcherTypes))
 	uploadCmd.Flags().StringVarP(&uploadOptions.containerInfo.Name, "watch-container", "", "", "For KubeAPI watcher, Wait for this container to exit.")
 	uploadCmd.Flags().StringVarP(&uploadOptions.containerInfo.Namespace, "namespace", "", "", "For KubeAPI watcher, Namespace of the pod [optional]")
-	uploadCmd.Flags().StringVarP(&uploadOptions.containerInfo.Name, "pod-name", "", "", "For KubeAPI watcher, Name of the pod [optional].")
+	uploadCmd.Flags().StringVarP(&uploadOptions.containerInfo.PodName, "pod-name", "", "", "For KubeAPI watcher, Name of the pod [optional].")
 	return uploadCmd
 }

--- a/cmd/sidecar.go
+++ b/cmd/sidecar.go
@@ -48,7 +48,7 @@ func (u *UploadOptions) createWatcher(ctx context.Context, w containerwatcher.Wa
 	case containerwatcher.WatcherTypeKubeAPI:
 		// TODO, in this case container info should have namespace and podname and we can get it using downwardapi
 		// TODO https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
-		return containerwatcher.NewKubeAPIWatcher(ctx, u.RootOptions.kubeClient.CoreV1(), u.containerInfo)
+		return containerwatcher.NewKubeAPIWatcher(ctx, u.RootOptions.clientConfig, u.containerInfo)
 	case containerwatcher.WatcherTypeFile:
 		return containerwatcher.NewSuccessFileWatcher(ctx, u.localDirectoryPath, StartFile, SuccessFile, ErrorFile)
 	case containerwatcher.WatcherTypeSharedProcessNS:


### PR DESCRIPTION
# TL;DR
Lazily load k8s client only in kubeapi watcher. This prevents init container errors when running with service accounts that have `automountServiceAccountToken: false` set. Smoke tested in sandbox with and without `automountServiceAccountToken: false`, with both the default shared process namespace watcher and kubeapi watcher respectively.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 Moved initialization of k8s client from copilot root command to `NewKubeAPIWatcher` function. Now it is only initialized when the `kube-api` watcher is specified.